### PR TITLE
Adding default to avoid warning if unset POST variable

### DIFF
--- a/functions/shorten.php
+++ b/functions/shorten.php
@@ -7,10 +7,11 @@ require_once(__DIR__."/UrlShortener.php");
 
 $errors       = false;
 $insertCustom = false;
+$onoffswitch  = isset($_POST['onoffswitch']) ? $_POST['onoffswitch'] : 'off';
 
 $urlShortener = new UrlShortener();
 
-if (($_POST['onoffswitch'] == 'on') && (isset($_POST['custom']))) {
+if (($onoffswitch == 'on') && (isset($_POST['custom']))) {
     $customCode = $_POST['custom'];
     
     if (!$urlShortener->checkUrlExistInDatabase($customCode)) {


### PR DESCRIPTION
There was a warning when custom links weren't used and $_POST['onoffswitch'] wasn't set